### PR TITLE
Improve .editorconfig and .sln

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,18 @@
 root = true
 
-[{.*,*.cs}]
+[{.*,*.md,*.cs,*.csproj,*.sln}]
 charset = utf-8
 end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[{*.md,*.csproj}]
+indent_size = 2
+
+[*.sln]
+indent_style = tab
 
 [*.cs]
 #### .NET Coding Conventions ####

--- a/CODBO4.sln
+++ b/CODBO4.sln
@@ -5,6 +5,10 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CODBO4", "CODBO4.csproj", "{DD98AF66-35AD-409C-AD16-C43FA5623A24}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C96563C5-A355-418D-9334-5197C95D76D4}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,7 +25,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		        SolutionGuid = {2051208A-E4C7-4553-83F8-4B2DD75FD5DB}
 		SolutionGuid = {CC643292-02CA-4370-8918-06837AB83C15}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
I realized I broke the solution file in #1. I just had the same problem and apparently .sln files don't like spaces as indentation. And you've already fixed that but I want to improve the editorconfig so it handles all files properly in the future.

I also added .md and .csproj with 2 spaces indentation.